### PR TITLE
Gemfile: add faraday as GCG dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :release do
+  gem 'faraday-retry', '~> 2.1', require: false
   gem 'github_changelog_generator', '~> 1.16.4', require: false
 end


### PR DESCRIPTION
github_changelog_generator has a soft dependency to faraday. If we don't add it to our Gemfile we will get a warning for each changelog generation.