### PR TITLE
build puppet 8 upon debian 12 upstream ruby image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/betadots/ruby:3.2.3-jammy
+ARG BASE_IMAGE=docker.io/ruby:3.2.5-bookworm
 
 FROM $BASE_IMAGE
 
@@ -59,9 +59,7 @@ RUN apt-get update \
     && rm -rf /usr/local/lib/ruby/gems/2.7.0/gems/cgi-0.1.0.2 \
     && rm -rf /usr/local/lib/ruby/gems/2.7.0/specifications/default/cgi-0.1.0.2.gemspec \
     && rm -rf /usr/local/lib/ruby/gems/2.7.0/gems/stringio-0.1.0 \
-    && rm -rf /usr/local/lib/ruby/gems/2.7.0/specifications/default/stringio-0.1.0.gemspec \
-    && rm -rf /usr/local/lib/ruby/gems/3.2.0/gems/rdoc-6.5.0 \
-    && rm -rf /usr/local/lib/ruby/gems/3.2.0/specifications/default/rdoc-6.5.0.gemspec
+    && rm -rf /usr/local/lib/ruby/gems/2.7.0/specifications/default/stringio-0.1.0.gemspec
 
 WORKDIR /repo
 

--- a/build_versions.json
+++ b/build_versions.json
@@ -17,7 +17,7 @@
     },
     {
       "puppet_release": 8,
-      "base_image": "ghcr.io/betadots/ruby:3.2.3-jammy",
+      "base_image": "docker.io/ruby:3.2.5-bookworm",
       "rubygem_puppet": "8.7.0",
       "rubygem_facter": "4.7.1",
       "rubygem_voxpupuli_test": "8.1.0",


### PR DESCRIPTION
back then when i first startet this project, this didn't work or was not new enough, but now debian 12 ruby upstream image is sufficient and working.

hope minor ruby update to 3.2.5 is okay, while puppet is shipping some older 3.2.2?