### PR TITLE
fix ghostbuster

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -103,6 +103,7 @@ COPY --from=builder /usr/local/lib/ruby/gems /usr/local/lib/ruby/gems
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY Containerfile /
 COPY voxbox/Rakefile /
+COPY voxbox/Gemfile /
 
 WORKDIR /repo
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ They can be combined with `--only-checks` and listed in a comma separated list.
 
 ```shell
 podman run -it --rm -v $PWD:/repo:Z --entrypoint ash ghcr.io/voxpupuli/voxbox:8
-find . -type f -exec puppet-lint --only-checks ghostbuster_classes,ghostbuster_facts {} \+
+find . -type f -exec bundle exec --gemfile /Gemfile puppet-lint --only-checks ghostbuster_classes,ghostbuster_facts {} \+
 ```
 
 ### YAMLlint


### PR DESCRIPTION
gems are installed using bundler.
If we want to use an extension installed via bundler, we must run bundler.
To do so we need the Gemfile which was used to build the container.

Besides this the execution of ghostbuster must be done using bundle exec puppet.lint instead of puppet-lint.