### PR TITLE
GitLab docs: run tests in parallel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,7 @@ qa-r10k-validate:
 test-unit:
   extends: .test
   script:
-    - $RAKE spec
+    - $RAKE parallel_spec
   rules:
     - if: '$CI_COMMIT_TAG == null'
       changes:


### PR DESCRIPTION
The `spec` task runs a single thread. `parallel_spec` starts one thread per CPU core and spreads all spec files across them. The Vox Pupuli default is also `parallel_spec`:
https://github.com/voxpupuli/gha-puppet/blob/c123130ff0a36133fa489055b285647a1c98b002/.github/workflows/basic.yml#L111